### PR TITLE
Fix default system-prompt.md saving issue

### DIFF
--- a/src/main/kotlin/io/fletchly/genius/config/PromptManager.kt
+++ b/src/main/kotlin/io/fletchly/genius/config/PromptManager.kt
@@ -48,7 +48,9 @@ class PromptManager @Inject constructor(private val plugin: JavaPlugin) {
      * Save default prompt to server
      */
     private fun saveDefaultPrompt() {
-        plugin.saveResource(promptPath, false)
+        if (plugin.getResource(promptPath) !== null) {
+            plugin.saveResource(promptPath, false)
+        }
     }
 
     /**


### PR DESCRIPTION
Make prompt manager only save default system prompt if one does not already exist. (Closes #17)